### PR TITLE
 Add 'get' Endpoint to Support Solr's Real-Time Get Handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 /WebService-Solr-Tiny-*
 *.swp
+
+# Ignore generated files from Perl Build
+Build
+MYMETA.json
+MYMETA.yml
+_build_params
+blib/

--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 {{$NEXT}}
 
     - Tweaks to minting process
+    - Add support for Solr's Realitime Get Handler
 
 0.002
 

--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 {{$NEXT}}
 
     - Tweaks to minting process
-    - Add support for Solr's Realitime Get Handler
+    - Add support for Solr's RealTime Get Handler
 
 0.002
 

--- a/lib/WebService/Solr/Tiny.pm
+++ b/lib/WebService/Solr/Tiny.pm
@@ -2,7 +2,7 @@ package WebService::Solr::Tiny 0.002;
 
 use v5.20;
 use warnings;
-use experimental qw/lexical_subs postderef signatures/;
+use experimental qw/lexical_subs postderef signatures state/;
 
 use Exporter 'import';
 use URI::Query::FromHash 0.003;
@@ -12,10 +12,9 @@ our @EXPORT_OK = qw/solr_escape solr_query/;
 sub new ( $class, %args ) {
     my $self = bless \%args, $class;
 
-    $self->{agent}        //=
-        do { require HTTP::Tiny; HTTP::Tiny->new( keep_alive => 1 ) };
-    $self->{decoder}      //=
-        do { require JSON::PP; \&JSON::PP::decode_json };
+    $self->{agent}
+        //= do { require HTTP::Tiny; HTTP::Tiny->new( keep_alive => 1 ) };
+    $self->{decoder} //= do { require JSON::PP; \&JSON::PP::decode_json };
     $self->{default_args} //= {};
     $self->{url}          //= 'http://localhost:8983/solr/select';
 
@@ -23,8 +22,31 @@ sub new ( $class, %args ) {
 }
 
 sub search ( $self, $q = '', %args ) {
-    my $reply = $self->{agent}->get( $self->{url} . '?' .
-        hash2query { $self->{default_args}->%*, q => $q, %args } );
+    my $url = $self->{url} . '?'
+        . hash2query { $self->{default_args}->%*, q => $q, %args };
+
+    $self->_request($url);
+}
+
+sub get ( $self, $document_ids, %args ) {
+    unless ( ref $document_ids eq 'ARRAY' && $document_ids->@* ) {
+        require Carp;
+        Carp::croak("Expected an array reference for 'document_ids'");
+    }
+
+    state $rt_get_base_url
+        = do { my $url = $self->{url}; $url =~ s/select/get/; $url };
+
+    my $url
+        = $rt_get_base_url . '?'
+        . hash2query { $self->{default_args}->%*, id => $document_ids,
+        %args };
+
+    $self->_request($url);
+}
+
+sub _request ( $self, $url ) {
+    my $reply = $self->{agent}->get($url);
 
     unless ( $reply->{success} ) {
         require Carp;
@@ -35,11 +57,11 @@ sub search ( $self, $q = '', %args ) {
     $self->{decoder}( $reply->{content} );
 }
 
-sub solr_escape ( $q ) { $q =~ s/([\Q+-&|!(){}[]^"~*?:\\\E])/\\$1/gr }
+sub solr_escape ($q) { $q =~ s/([\Q+-&|!(){}[]^"~*?:\\\E])/\\$1/gr }
 
 # For solr_query
 my ( %struct, %value, %op );
-sub solr_query ( $x ) { $struct{ARRAY}->( ref $x eq 'ARRAY' ? $x : [ $x ] ) }
+sub solr_query ($x) { $struct{ARRAY}->( ref $x eq 'ARRAY' ? $x : [$x] ) }
 
 my sub dispatch ( $table, $name, @args ) {
     ( $table->{$name} // die "Cannot dispatch to $name" )->(@args);
@@ -51,19 +73,20 @@ my sub pair ( $k, $v ) {
     if ( ref $v eq 'ARRAY' && ( $v->[0] // '' ) =~ /^-(AND|OR)$/i ) {
         my ( $op, undef, @val ) = ( uc $1, @$v );
         return sprintf '(%s)',
-            join " $op ", map '(' . $struct{HASH}->({ $k => $_ }) . ')', @val;
+            join " $op ", map '(' . $struct{HASH}->( { $k => $_ } ) . ')',
+            @val;
     }
 
     dispatch( \%value, ref $v || 'SCALAR', $k, $v );
 }
 
-$struct{HASH} = sub( $x ) {
+$struct{HASH} = sub ($x) {
     join ' AND ', map {
         /^-(.+)/ ? dispatch( \%op, $1, $x->{$_} ) : pair( $_, $x->{$_} )
     } sort keys %$x;
 };
 
-$struct{ARRAY} = sub ( $x ) {
+$struct{ARRAY} = sub ($x) {
     '(' . join( ' OR ', map dispatch( \%struct, ref $_, $_ ), @$x ) . ')';
 };
 
@@ -81,11 +104,11 @@ $value{ARRAY} = sub ( $k, $v ) {
     '(' . join( ' OR ', map $value{SCALAR}->( $k, $_ ), @$v ) . ')';
 };
 
-$op{default}   = sub (     $v ) { pair( '', $v ) };
+$op{default}   = sub ($v) { pair( '', $v ) };
 $op{require}   = sub ( $k, $v ) { qq(+$k:") . solr_escape($v) . '"' };
 $op{prohibit}  = sub ( $k, $v ) { qq(-$k:") . solr_escape($v) . '"' };
-$op{range}     = sub ( $k, $v ) { "$k:[$v->[ 0 ] TO $v->[ 1 ]]" };
-$op{range_exc} = sub ( $k, $v ) { "$k:{$v->[ 0 ] TO $v->[ 1 ]}" };
+$op{range}     = sub ( $k, $v ) {"$k:[$v->[ 0 ] TO $v->[ 1 ]]"};
+$op{range_exc} = sub ( $k, $v ) {"$k:{$v->[ 0 ] TO $v->[ 1 ]}"};
 $op{range_inc} = $op{range};
 
 $op{boost} = sub ( $k, $extra ) {

--- a/lib/WebService/Solr/Tiny.pod
+++ b/lib/WebService/Solr/Tiny.pod
@@ -39,6 +39,13 @@ WebService::Solr::Tiny - Perl interface to Apache Solr
      start      => 10,
  );
 
+ # Retrieve documents by ID
+ my $document_ids = [1, 2, 3];
+ $solr->get($document_ids);
+
+ # Pass extra parameters to Solr where retriving the documents
+ $solr->get($document_ids, debugQuery => 'true');
+
 =head1 DESCRIPTION
 
 WebService::Solr::Tiny is similar to, and inspired by L<WebService::Solr>,
@@ -83,7 +90,7 @@ C<decode_json> from L<JSON::PP>.
 
 A hash reference with default parameters that will be passed along as part of
 every request. The values in this hash will be merged with those passed to
-C<search>. Defaults to an empty hash reference.
+C<search> and C<get>. Defaults to an empty hash reference.
 
 =item C<url>
 
@@ -115,6 +122,67 @@ content of the response.
 On success, the full content of the response will be passed to the code ref
 specified in the C<decoder> parameter to the constructor, and the result of
 this will be this method's return value.
+
+=head2 get
+
+Sends a request to the Solr 'get' endpoint. Takes an array reference of
+document IDs to be fetched and an optional list of key-value pairs to be
+used as additional parameters to qualify the request.
+
+The C<document_ids> parameter is expected to be an array reference
+containing the IDs of the documents to retrieve. If this parameter is not
+provided as an array reference, or if it is empty, the method will croak
+with an appropriate error message.
+
+The final set of parameters, including the document IDs, will be converted
+to a query parameter string using L<URI::Query::FromHash>. Each document
+ID will be added to the query string as a separate C<id> parameter,
+allowing multiple IDs to be requested in a single call.
+
+If any value has been set as part of the C<default_args> in the constructor,
+these will be merged with the arguments to this function.
+
+In the event of a failure of any kind (e.g., if the Solr request fails),
+this function will croak with the content of the response.
+
+On success, the full content of the response will be passed to the code
+reference specified in the C<decoder> parameter to the constructor, and the
+result of this will be this method's return value.
+
+=head3 Additional Resources
+
+For more information on the real-time get handler and its benefits,
+including faster retrieval of documents by ID, refer to the Solr documentation at
+L<https://solr.apache.org/guide/solr/latest/configuration-guide/realtime-get.html>.
+
+=head3 Parameters
+
+=over 4
+
+=item * C<document_ids>
+
+An array reference containing the IDs of the documents to fetch. This is a
+required parameter.
+
+=item * C<%args>
+
+An optional list of additional key-value pairs to be sent as query
+parameters. These parameters will be merged with any default arguments set
+in the constructor.
+
+=back
+
+=head3 Exceptions
+
+This method can croak under the following conditions:
+
+=over 4
+
+=item * If C<document_ids> is not provided as an array reference.
+
+=item * If C<document_ids> is empty (i.e., no document IDs provided).
+
+=back
 
 =head1 PERFORMANCE
 

--- a/t/01-namespace.t
+++ b/t/01-namespace.t
@@ -1,11 +1,9 @@
 use Test2::V0;
 use WebService::Solr::Tiny;
 
-is [ sort keys %WebService::Solr::Tiny:: ] => [
-    qw/
-        BEGIN EXPORT EXPORT_OK VERSION __ANON__
-        _request get import new search solr_escape solr_query
-        /
-];
+is [ sort keys %WebService::Solr::Tiny:: ] => [ qw/
+    BEGIN EXPORT EXPORT_OK VERSION __ANON__
+    get import new search solr_escape solr_query
+/];
 
 done_testing;

--- a/t/01-namespace.t
+++ b/t/01-namespace.t
@@ -1,9 +1,11 @@
 use Test2::V0;
 use WebService::Solr::Tiny;
 
-is [ sort keys %WebService::Solr::Tiny:: ] => [ qw/
-    BEGIN EXPORT EXPORT_OK VERSION __ANON__
-    import new search solr_escape solr_query
-/];
+is [ sort keys %WebService::Solr::Tiny:: ] => [
+    qw/
+        BEGIN EXPORT EXPORT_OK VERSION __ANON__
+        _request get import new search solr_escape solr_query
+        /
+];
 
 done_testing;

--- a/t/06-get.t
+++ b/t/06-get.t
@@ -1,7 +1,9 @@
 use Test2::V0;
 use WebService::Solr::Tiny;
 
-my $solr = WebService::Solr::Tiny->new( agent => mock {} => add =>
+my $solr = WebService::Solr::Tiny->new(
+    base_url => "http://localhost:8983/solr/",
+    agent => mock {} => add =>
         [ get => sub { $::req = pop; { content => '{}', success => 1 } } ] );
 
 subtest 'Fetching documents but id' => sub {
@@ -48,7 +50,7 @@ subtest 'Fetching documents but id' => sub {
         'original endpoint is not changed';
 };
 
-subtest 'Execptions' => sub {
+subtest 'Exceptions' => sub {
     like dies { $solr->get }, qr/Too few arguments/;
 
     like dies { $solr->get(undef) }, qr/Expected an array reference/;
@@ -56,6 +58,20 @@ subtest 'Execptions' => sub {
     like dies { $solr->get(1) }, qr/Expected an array reference/;
 
     like dies { $solr->get( [] ) }, qr/Expected an array reference/;
+
+    like dies { WebService::Solr::Tiny->new(
+        base_url => "http://localhost:8983/solr/",
+        url => "http://localhost:8983/solr/select",
+        agent => mock {} => add =>
+            [ get => sub { $::req = pop; { content => '{}', success => 1 } } ] );
+    }, qr/Cannot specify both 'url' and 'base_url'./;
+
+    my $solr = WebService::Solr::Tiny->new(
+        url => "http://localhost:8983/solr/",
+        agent => mock {} => add =>
+            [ get => sub { $::req = pop; { content => '{}', success => 1 } } ] );
+
+    like dies { $solr->get( [1,2,3] ) }, qr/construct it with 'base_url'/;
 };
 
 done_testing;

--- a/t/06-get.t
+++ b/t/06-get.t
@@ -1,0 +1,61 @@
+use Test2::V0;
+use WebService::Solr::Tiny;
+
+my $solr = WebService::Solr::Tiny->new( agent => mock {} => add =>
+        [ get => sub { $::req = pop; { content => '{}', success => 1 } } ] );
+
+subtest 'Fetching documents but id' => sub {
+    $solr->get( [1] );
+    is $::req, 'http://localhost:8983/solr/get?id=1';
+
+    $solr->get( [ 1 .. 3 ] );
+    is $::req, 'http://localhost:8983/solr/get?id=1&id=2&id=3';
+
+    $solr->get( ['UTF-8 FTW ☃'] );
+    is $::req, 'http://localhost:8983/solr/get?id=UTF-8+FTW+%E2%98%83';
+
+    $solr->get(
+        [ 1 .. 30 ],
+        debugQuery => 'true',
+        fl         => 'id,name,price',
+        fq         => [ 'popularity:[10 TO *]', 'section:0' ],
+        omitHeader => 'true',
+        rows       => 20,
+        sort       => 'inStock desc, price asc',
+        start      => 10,
+    );
+
+    is [ sort split /[?&]/, $::req ] => [
+        qw[
+            debugQuery=true
+            fl=id%2Cname%2Cprice
+            fq=popularity%3A%5B10+TO+*%5D
+            fq=section%3A0
+            http://localhost:8983/solr/get
+        ],
+        ( sort map {"id=$_"} ( 1 .. 30 ) ),
+        qw[
+            omitHeader=true
+            rows=20
+            sort=inStock+desc%2C+price+asc
+            start=10
+        ]
+    ];
+
+    $solr->get( ['A'] );
+    is $::req, 'http://localhost:8983/solr/get?id=A';
+    is $solr->{url}, 'http://localhost:8983/solr/select',
+        'original endpoint is not changed';
+};
+
+subtest 'Execptions' => sub {
+    like dies { $solr->get }, qr/Too few arguments/;
+
+    like dies { $solr->get(undef) }, qr/Expected an array reference/;
+
+    like dies { $solr->get(1) }, qr/Expected an array reference/;
+
+    like dies { $solr->get( [] ) }, qr/Expected an array reference/;
+};
+
+done_testing;


### PR DESCRIPTION

This PR introduces a get endpoint for WebService::Solr::Tiny to support Solr's Real-Time Get Handler, enabling faster retrieval of documents by ID(s). This is particularly useful when retrieving individual documents by id, as it is more efficient than using the select endpoint.
The structure for the 'get' function ended up being quite similar to 'search', so the common code has been moved to an internal function.